### PR TITLE
Fixes two issues that led to pipeline failure

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -12,8 +12,8 @@ def helpMessage() {
 
 if (!params.output_file.endsWith('csv')) exit 1, "You have specified the --output_file to be '${params.output_file}', which does not indicate a comma sepearated file.\nPlease specify an output file name with --output_file that ends with .csv"
 
-Channel.fromPath("${params.s3_location}/**/*.{${params.file_suffix},${params.index_suffix}}")
-       .map { it -> [ file(it).baseName.minus(".${params.file_suffix}").minus(".${params.index_suffix}"), "s3:/"+it] }
+Channel.fromPath("${params.s3_location}/**.{${params.file_suffix},${params.index_suffix}}")
+       .map { it -> [ file(it).name.minus(".${params.index_suffix}").minus(".${params.file_suffix}"), "s3:/"+it] }
        .groupTuple(by:0)
        .set { ch_files }
 


### PR DESCRIPTION
1) s3 path was coded with both wildcards ../**/*... which meant
nextflow/aws cli expected at least one folder of depth between specified
folder and actual files because of /**/, which meant that nothing will
be found if you provide exact folder with vcf files (except if it has
another subfolder). I tested and .../**.vcf.gz finds all files in the
specified folder AND all included subfolders recursively. No need to do
/**/*.vcf, its enough to just do .../**.vcf

2) File extensions were not trimmed correctly with .minus() method,
because it was invoked on baseName-ed file name, which already trimms
away last extension. So .minus() method didn't find correct pattern to
trim and missed the step, which lead to consequent groupping operation
failure. Solution - we had to use .name() on file, that doesn't trimm
any extensions itself. Using .name() solved the issue.